### PR TITLE
refactor: migrate AI de-identification to use vectorized Python UDF

### DIFF
--- a/ai_deidentify_batch.sql
+++ b/ai_deidentify_batch.sql
@@ -14,134 +14,17 @@
 
 -- ============================================================================
 -- AI De-identification Batch Processing
--- Batch versions of entity extraction and de-identification functions
--- Requires: ai_deidentify.sql to be executed first for base functions
+-- Uses vectorized UDF (LLM_EXTRACT_ENTITIES_BATCH) from ai_deidentify_batch_vectorized.sql
+-- Requires: 
+--   1. ai_deidentify.sql for base functions (CLEAN_SENSITIVE_VALUE, TOKENIZE_SENSITIVE_VALUE)
+--   2. ai_deidentify_batch_vectorized.sql for LLM_EXTRACT_ENTITIES_BATCH vectorized UDF
 -- ============================================================================
 
 -- ============================================================================
--- LLM_EXTRACT_ENTITIES_BATCH
--- Extracts entities from multiple texts in a single LLM call
--- ============================================================================
-
-CREATE OR REPLACE FUNCTION LLM_EXTRACT_ENTITIES_BATCH(raw_texts ARRAY)
-RETURNS OBJECT
-LANGUAGE SQL
-AS
-$$
-SNOWFLAKE.CORTEX.TRY_COMPLETE(
-    'claude-sonnet-4-5',
-    [
-        {
-            'role': 'system',
-            'content': '
-            Act as a sensitive data extraction system. You will receive MULTIPLE text records to process in a single batch.
-            Each record is prefixed with [RECORD_N] where N is the record index (0-based).
-            
-            For EACH record, extract all instances of the following Information Types (INFO_TYPES):
-            -   PERSON_NAME
-            -   AUSTRALIAN_PHONE_NUMBER
-            -   EMAIL_ADDRESS
-            -   AUSTRALIAN_DRIVERS_LICENSE
-            -   CREDIT_CARD_NUMBER
-
-            ---
-            VALIDATION RULES (only extract if valid):
-
-            AUSTRALIAN_PHONE_NUMBER - Must satisfy ALL:
-              * Contains 10 digits total (excluding country code +61)
-              * Mobile numbers start with 04 (or +614)
-              * Landline numbers start with 02, 03, 07, or 08 (area codes)
-              * DO NOT flag: numbers with fewer than 10 digits, numbers starting with invalid prefixes, order IDs, ticket numbers, or reference codes
-
-            CREDIT_CARD_NUMBER - Must satisfy ALL:
-              * Contains exactly 13-19 digits
-              * Starts with valid prefix: 4 (Visa), 5 (Mastercard), 3 (Amex/Diners), 6 (Discover)
-              * DO NOT flag: numbers that are too short/long, sequential numbers like 1234567890, or obviously fake patterns like 0000-0000-0000-0000
-
-            EMAIL_ADDRESS - Must satisfy ALL:
-              * Contains exactly one @ symbol
-              * Has valid format: local-part@domain.tld
-              * Domain has at least one dot with valid TLD
-              * DO NOT flag: partial emails, @mentions without domain, or malformed addresses like "user@" or "@domain.com"
-
-            AUSTRALIAN_DRIVERS_LICENSE - Must match ONE of these state formats:
-              * NSW (New South Wales): 6-8 alphanumeric characters
-              * VIC (Victoria): 9-10 digits only
-              * QLD (Queensland): 8-9 digits only
-              * SA (South Australia): 6 alphanumeric characters
-              * WA (Western Australia): 7 digits only
-              * TAS (Tasmania): 6-8 alphanumeric characters
-              * NT (Northern Territory): 6-10 digits only
-              * ACT (Australian Capital Territory): 10 digits only
-              * May be prefixed with state code (e.g., "NSW12345678", "VIC-123456789")
-              * DO NOT flag: short numeric codes, order/reference numbers, or IDs that dont match above patterns
-
-            ---
-            OUTPUT CONSTRAINTS:
-            * Return a "results" array where each element corresponds to the input record at that index
-            * Each result contains an "entities" array for that specific record
-            * DO NOT EXTRACT URLs or invalid data
-            * The value MUST be the exact substring from the original text
-            * DO NOT normalize or reformat values
-            '
-        },
-        {
-            'role': 'user',
-            'content': (
-                SELECT LISTAGG('[RECORD_' || idx || ']\n' || val || '\n\n', '')
-                FROM (SELECT INDEX as idx, VALUE::STRING as val FROM TABLE(FLATTEN(raw_texts)))
-            )
-        }
-    ],
-    {         
-        'max_tokens': 16384,
-        'response_format': {
-            'type': 'json',
-            'schema': {
-                'type': 'object',
-                'properties': {
-                    'results': {
-                        'type': 'array',
-                        'items': {
-                            'type': 'object',
-                            'properties': {
-                                'record_index': {
-                                    'type': 'integer'
-                                },
-                                'entities': {
-                                    'type': 'array',
-                                    'items': {
-                                        'type': 'object',
-                                        'properties': {
-                                            'info_type': {
-                                                'type': 'string',
-                                                'enum': ['PERSON_NAME', 'AUSTRALIAN_PHONE_NUMBER', 'EMAIL_ADDRESS', 'AUSTRALIAN_DRIVERS_LICENSE', 'CREDIT_CARD_NUMBER']
-                                            },
-                                            'value': {
-                                                'type': 'string'
-                                            }
-                                        },
-                                        'required': ['info_type', 'value']
-                                    }
-                                }
-                            },
-                            'required': ['record_index', 'entities']
-                        }
-                    }
-                },
-                'required': ['results']
-            }
-        }
-    }
-)
-$$;
-
--- ============================================================================
--- DEIDENTIFY_TEXT_BATCH
--- Batch version of DEIDENTIFY_TEXT - processes multiple texts in one LLM call
+-- AI_DEIDENTIFY_TEXT_BATCH
+-- Batch version of DEIDENTIFY_TEXT - processes multiple texts using vectorized UDF
 -- Input: Array of raw text strings
 -- Output: Array of objects, each containing deidentified_text and extracted_entities
--- Requires: CLEAN_SENSITIVE_VALUE and TOKENIZE_SENSITIVE_VALUE from ai_deidentify.sql
 -- ============================================================================
 
 CREATE OR REPLACE FUNCTION AI_DEIDENTIFY_TEXT_BATCH(raw_texts ARRAY)
@@ -149,84 +32,153 @@ RETURNS ARRAY
 LANGUAGE SQL
 AS
 $$
-SELECT TRANSFORM(
-    LLM_EXTRACT_ENTITIES_BATCH(raw_texts):structured_output[0]:raw_message:results,
-    r -> (
-        SELECT OBJECT_CONSTRUCT(
-            'record_index', r:record_index::INT,
-            'original_text', raw_texts[r:record_index::INT],
-            'deidentified_text',
+WITH extracted AS (
+    SELECT 
+        f.index as idx,
+        f.value::STRING as raw_text,
+        LLM_EXTRACT_ENTITIES_BATCH(f.value::STRING) as extraction_result
+    FROM TABLE(FLATTEN(raw_texts)) f
+),
+with_entities AS (
+    SELECT 
+        idx,
+        raw_text,
+        extraction_result,
+        TRANSFORM(
+            TRANSFORM(
+                FILTER(
+                    extraction_result:entities,
+                    e -> e:value IS NOT NULL AND e:info_type IS NOT NULL
+                ),
+                e -> OBJECT_CONSTRUCT(
+                    'type', e:info_type::STRING,
+                    'value', e:value::STRING,
+                    'cleaned_value', CLEAN_SENSITIVE_VALUE(e:info_type::STRING, e:value::STRING)
+                )
+            ),
+            e -> OBJECT_INSERT(e, 'token', TOKENIZE_SENSITIVE_VALUE(e:cleaned_value::STRING))
+        ) AS cleaned_entities
+    FROM extracted
+)
+SELECT ARRAY_AGG(
+    OBJECT_CONSTRUCT(
+        'record_index', idx,
+        'original_text', raw_text,
+        'success', extraction_result:success::BOOLEAN,
+        'deidentified_text',
+        CASE 
+            WHEN extraction_result:success::BOOLEAN THEN
+                REDUCE(
+                    cleaned_entities,
+                    raw_text,
+                    (acc, el) -> REPLACE(
+                        acc,
+                        el:value::STRING,
+                        '__ENTITY_' || el:type::STRING || '(' || el:token::STRING || ')__'
+                    )
+                )
+            ELSE raw_text
+        END,
+        'extracted_entities', cleaned_entities,
+        '_meta', extraction_result:_meta
+    )
+) WITHIN GROUP (ORDER BY idx)
+FROM with_entities
+$$;
+
+-- ============================================================================
+-- AI_DEIDENTIFY_TEXT - Scalar wrapper (convenience function)
+-- Processes a single text using the vectorized UDF
+-- Snowflake automatically batches multiple scalar calls for efficiency
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION AI_DEIDENTIFY_TEXT(raw_text VARCHAR)
+RETURNS OBJECT
+LANGUAGE SQL
+AS
+$$
+WITH extracted AS (
+    SELECT LLM_EXTRACT_ENTITIES_BATCH(raw_text) as extraction_result
+),
+with_entities AS (
+    SELECT 
+        extraction_result,
+        TRANSFORM(
+            TRANSFORM(
+                FILTER(
+                    extraction_result:entities,
+                    e -> e:value IS NOT NULL AND e:info_type IS NOT NULL
+                ),
+                e -> OBJECT_CONSTRUCT(
+                    'type', e:info_type::STRING,
+                    'value', e:value::STRING,
+                    'cleaned_value', CLEAN_SENSITIVE_VALUE(e:info_type::STRING, e:value::STRING)
+                )
+            ),
+            e -> OBJECT_INSERT(e, 'token', TOKENIZE_SENSITIVE_VALUE(e:cleaned_value::STRING))
+        ) AS cleaned_entities
+    FROM extracted
+)
+SELECT OBJECT_CONSTRUCT(
+    'original_text', raw_text,
+    'success', extraction_result:success::BOOLEAN,
+    'deidentified_text',
+    CASE 
+        WHEN extraction_result:success::BOOLEAN THEN
             REDUCE(
                 cleaned_entities,
-                raw_texts[r:record_index::INT]::STRING,
+                raw_text::STRING,
                 (acc, el) -> REPLACE(
                     acc,
                     el:value::STRING,
                     '__ENTITY_' || el:type::STRING || '(' || el:token::STRING || ')__'
                 )
-            ),
-            'extracted_entities', cleaned_entities
-        )
-        FROM (
-            SELECT TRANSFORM(
-                TRANSFORM(
-                    FILTER(
-                        r:entities,
-                        e -> e:value IS NOT NULL AND e:info_type IS NOT NULL
-                    ),
-                    e -> OBJECT_CONSTRUCT(
-                        'type', e:info_type::STRING,
-                        'value', e:value::STRING,
-                        'cleaned_value', CLEAN_SENSITIVE_VALUE(e:info_type::STRING, e:value::STRING)
-                    )
-                ),
-                e -> OBJECT_INSERT(e, 'token', TOKENIZE_SENSITIVE_VALUE(e:cleaned_value::STRING))
-            ) AS cleaned_entities
-        )
-    )
+            )
+        ELSE raw_text
+    END,
+    'extracted_entities', cleaned_entities,
+    '_meta', extraction_result:_meta
 )
+FROM with_entities
 $$;
 
 -- ============================================================================
 -- Example Usage:
 -- ============================================================================
 -- 
--- -- Process multiple texts in one LLM call
+-- -- Process single text (Snowflake auto-batches when used on multiple rows)
+-- SELECT AI_DEIDENTIFY_TEXT('Contact John Smith at john@email.com or 0412 345 678');
+--
+-- -- Extract fields from scalar result
+-- SELECT 
+--     result:success::BOOLEAN as success,
+--     result:deidentified_text::STRING as deidentified,
+--     result:extracted_entities as entities
+-- FROM (
+--     SELECT AI_DEIDENTIFY_TEXT('Contact John Smith at john@email.com') as result
+-- );
+--
+-- -- Process multiple texts in one call
 -- SELECT AI_DEIDENTIFY_TEXT_BATCH(
 --     ARRAY_CONSTRUCT(
 --         'Contact John Smith at john@email.com or 0412 345 678',
---         'Sarah Connor, license NSW12345678, called about order',
---         'Technical issue - check https://api.example.com for logs'
+--         'Sarah Connor, license NSW12345678, called about order'
 --     )
 -- );
 --
--- -- Flatten batch results for analysis
+-- -- Process table data efficiently (vectorized UDF handles batching automatically)
 -- SELECT 
---     r.value:record_index::INT as record_index,
---     r.value:original_text::STRING as original_text,
---     r.value:deidentified_text::STRING as deidentified_text,
---     r.value:extracted_entities as entities
--- FROM TABLE(FLATTEN(
---     AI_DEIDENTIFY_TEXT_BATCH(
---         ARRAY_CONSTRUCT(
---             'Call Jane Doe at 0412-999-888',
---             'Email support@company.com for help'
---         )
---     )
--- )) r;
+--     id,
+--     raw_text,
+--     AI_DEIDENTIFY_TEXT(raw_text) as result
+-- FROM my_table;
 --
--- -- Process table data in batches (recommended batch size: 5-15 records)
--- WITH batched AS (
---     SELECT 
---         FLOOR((ROW_NUMBER() OVER (ORDER BY id) - 1) / 10) as batch_id,
---         ARRAY_AGG(raw_text) WITHIN GROUP (ORDER BY id) as texts,
---         ARRAY_AGG(id) WITHIN GROUP (ORDER BY id) as ids
---     FROM my_table
---     GROUP BY batch_id
--- )
+-- -- Extract specific fields from table
 -- SELECT 
---     b.ids[r.value:record_index::INT] as original_id,
---     r.value:deidentified_text::STRING as deidentified_text,
---     r.value:extracted_entities as entities
--- FROM batched b,
--- TABLE(FLATTEN(AI_DEIDENTIFY_TEXT_BATCH(b.texts))) r;
+--     id,
+--     result:deidentified_text::STRING as deidentified_text,
+--     result:extracted_entities as entities
+-- FROM (
+--     SELECT id, AI_DEIDENTIFY_TEXT(raw_text) as result
+--     FROM my_table
+-- );

--- a/ai_deidentify_batch_vectorized.sql
+++ b/ai_deidentify_batch_vectorized.sql
@@ -1,0 +1,284 @@
+-- Copyright 2025 Snowflake Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- ============================================================================
+-- AI De-identification Batch Processing - Vectorized UDF with Cortex REST API
+-- Architecture-A: Warehouse-Native Vectorized UDF with Prompt Caching
+-- Requires: ai_deidentify.sql to be executed first for base functions
+-- ============================================================================
+
+-- ============================================================================
+-- STEP 1: Security Configuration
+-- Run these steps in order. Steps 1.4-1.5 require manual intervention.
+-- ============================================================================
+
+-- 1.1 Create the Network Rule (Egress to Self - Loopback)
+-- IMPORTANT: Replace <your-org>-<your-account> with your actual account identifier
+-- Use the format from your Snowsight URL (e.g., sfpscogs-adamle-aws-3)
+CREATE OR REPLACE NETWORK RULE snowflake_cortex_egress_rule
+    MODE = EGRESS
+    TYPE = HOST_PORT
+    VALUE_LIST = ('sfpscogs-adamle-aws-3.snowflakecomputing.com');
+
+-- 1.2 Generate Programmatic Access Token (PAT) for your CURRENT user
+-- IMPORTANT: Run this command and SAVE the token_secret value from the output.
+-- The token is only shown ONCE and cannot be retrieved later.
+ALTER USER CURRENT_USER() ADD PROGRAMMATIC ACCESS TOKEN cortex_vectorized_udf_pat;
+
+-- 1.3 Store the Token in a Secret
+-- Replace '<PASTE_YOUR_PAT_TOKEN_SECRET_HERE>' with the token_secret from step 1.2
+CREATE OR REPLACE SECRET cortex_auth_token
+    TYPE = GENERIC_STRING
+    SECRET_STRING = '<PASTE_YOUR_PAT_TOKEN_SECRET_HERE>';
+
+-- 1.4 Create External Access Integration
+-- Binds the network rule and secret together for use by the UDF
+CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION cortex_loopback_integration
+    ALLOWED_NETWORK_RULES = (snowflake_cortex_egress_rule)
+    ALLOWED_AUTHENTICATION_SECRETS = (cortex_auth_token)
+    ENABLED = TRUE;
+
+-- ============================================================================
+-- STEP 2: Vectorized Python UDF with Prompt Caching
+-- Uses @vectorized decorator to receive batches as pandas DataFrame.
+-- Snowflake automatically batches rows for efficient processing.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION LLM_EXTRACT_ENTITIES_BATCH(raw_text VARCHAR)
+RETURNS VARIANT
+LANGUAGE PYTHON
+RUNTIME_VERSION = '3.10'
+PACKAGES = ('snowflake-snowpark-python', 'pandas', 'aiohttp')
+HANDLER = 'extract_entities_batch'
+EXTERNAL_ACCESS_INTEGRATIONS = (cortex_loopback_integration)
+SECRETS = ('cred' = cortex_auth_token)
+AS $$
+"""
+Vectorized UDF for batch entity extraction using Cortex REST API.
+Features: Dynamic batching, parallel API calls, SSE parsing, prompt caching.
+"""
+import json
+import asyncio
+import aiohttp
+import pandas as pd
+from _snowflake import get_generic_secret_string, vectorized
+
+# =============================================================================
+# Configuration
+# =============================================================================
+API_ENDPOINT = "https://sfpscogs-adamle-aws-3.snowflakecomputing.com/api/v2/cortex/inference:complete"
+MODEL = "claude-sonnet-4-5"
+MAX_INPUT_TOKENS = 150000
+MAX_OUTPUT_TOKENS = 14000
+TOKENS_PER_CHAR = 0.25
+OUTPUT_TOKENS_PER_RECORD = 150
+
+SYSTEM_PROMPT = """Extract sensitive entities from text records prefixed with [RECORD_N].
+
+INFO_TYPES: PERSON_NAME, AUSTRALIAN_PHONE_NUMBER (10 digits, 04/02/03/07/08), 
+EMAIL_ADDRESS, AUSTRALIAN_DRIVERS_LICENSE (state-specific formats), CREDIT_CARD_NUMBER (13-19 digits).
+
+Rules: Return exact substrings only. Skip invalid patterns.
+Output: {"results": [{"record_index": N, "entities": [{"info_type": "...", "value": "..."}]}]}"""
+
+RESPONSE_SCHEMA = {"type": "json", "schema": {
+    "type": "object", "required": ["results"],
+    "properties": {"results": {"type": "array", "items": {
+        "type": "object", "required": ["record_index", "entities"],
+        "properties": {
+            "record_index": {"type": "integer"},
+            "entities": {"type": "array", "items": {
+                "type": "object", "required": ["info_type", "value"],
+                "properties": {
+                    "info_type": {"type": "string", "enum": [
+                        "PERSON_NAME", "AUSTRALIAN_PHONE_NUMBER", "EMAIL_ADDRESS",
+                        "AUSTRALIAN_DRIVERS_LICENSE", "CREDIT_CARD_NUMBER"]},
+                    "value": {"type": "string"}
+                }
+            }}
+        }
+    }}}
+}}
+
+# =============================================================================
+# Core Functions
+# =============================================================================
+def create_batches(texts):
+    """Split texts into sub-batches within token limits."""
+    batches, batch = [], {"texts": [], "indices": [], "tokens": 0}
+    for idx, text in enumerate(texts):
+        tokens = int(len(f"[RECORD_{idx}]\n{text}\n\n") * TOKENS_PER_CHAR)
+        if batch["texts"] and (batch["tokens"] + tokens > MAX_INPUT_TOKENS or
+                               len(batch["texts"]) * OUTPUT_TOKENS_PER_RECORD > MAX_OUTPUT_TOKENS):
+            batches.append(batch)
+            batch = {"texts": [], "indices": [], "tokens": 0}
+        batch["texts"].append(text)
+        batch["indices"].append(idx)
+        batch["tokens"] += tokens
+    if batch["texts"]:
+        batches.append(batch)
+    return batches
+
+async def call_api(session, texts, indices, token):
+    """Call Cortex API for a batch and return mapped results."""
+    payload = {
+        "model": MODEL,
+        "messages": [
+            {"role": "system", "content_list": [
+                {"type": "text", "text": SYSTEM_PROMPT, "cache_control": {"type": "ephemeral"}}]},
+            {"role": "user", "content": "\n\n".join(f"[RECORD_{i}]\n{t}" for i, t in enumerate(texts))}
+        ],
+        "response_format": RESPONSE_SCHEMA,
+        "max_tokens": min(MAX_OUTPUT_TOKENS, len(texts) * OUTPUT_TOKENS_PER_RECORD + 500),
+        "temperature": 0
+    }
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json",
+               "Accept": "application/json, text/event-stream"}
+    
+    try:
+        async with session.post(API_ENDPOINT, json=payload, headers=headers,
+                                timeout=aiohttp.ClientTimeout(total=300)) as resp:
+            if resp.status != 200:
+                return {"error": f"HTTP_{resp.status}", "indices": indices}
+            
+            content, usage = "", {}
+            async for line in resp.content:
+                line = line.decode('utf-8').strip()
+                if line.startswith('data:'):
+                    try:
+                        chunk = json.loads(line[5:].strip())
+                        content += chunk.get("choices", [{}])[0].get("delta", {}).get("content", "")
+                        if "usage" in chunk:
+                            usage = chunk["usage"]
+                    except json.JSONDecodeError:
+                        pass
+            
+            result_map = {r.get("record_index", i): r.get("entities", [])
+                          for i, r in enumerate(json.loads(content).get("results", []) if content else [])}
+            return {"results": {orig: result_map.get(i, []) for i, orig in enumerate(indices)}, "usage": usage}
+    except Exception as e:
+        return {"error": str(e)[:200], "indices": indices}
+
+async def process_all(texts, token):
+    """Process all batches in parallel."""
+    batches = create_batches(texts)
+    results, usage, errors = {}, {"prompt_tokens": 0, "completion_tokens": 0}, []
+    
+    async with aiohttp.ClientSession() as session:
+        responses = await asyncio.gather(*[call_api(session, b["texts"], b["indices"], token) for b in batches],
+                                         return_exceptions=True)
+    for resp in responses:
+        if isinstance(resp, Exception) or "error" in resp:
+            errors.append(resp if isinstance(resp, dict) else {"error": str(resp)})
+        else:
+            results.update(resp.get("results", {}))
+            for k in usage:
+                usage[k] += resp.get("usage", {}).get(k, 0)
+    return {"results": results, "usage": usage, "errors": errors, "num_batches": len(batches)}
+
+# =============================================================================
+# UDF Entry Point
+# =============================================================================
+@vectorized(input=pd.DataFrame, max_batch_size=100)
+def extract_entities_batch(df):
+    """Vectorized handler - process batch of rows, return entity results."""
+    token = get_generic_secret_string('cred')
+    texts = df.iloc[:, 0].fillna("").astype(str).tolist()
+    if not texts:
+        return pd.Series([{"success": True, "entities": []}] * len(df))
+    
+    loop = asyncio.new_event_loop()
+    try:
+        result = loop.run_until_complete(process_all(texts, token))
+    finally:
+        loop.close()
+    
+    error_idx = {e.get("indices", [None])[0] for e in result["errors"] if isinstance(e, dict)}
+    meta = {"num_batches": result["num_batches"], **result["usage"]}
+    return pd.Series([
+        {"success": False, "entities": [], "error": "BATCH_ERROR"} if i in error_idx
+        else {"success": True, "entities": result["results"].get(i, []), "_meta": meta}
+        for i in range(len(df))
+    ])
+$$;
+
+-- ============================================================================
+-- STEP 3: AI_DEIDENTIFY_TEXT - Scalar wrapper using the vectorized UDF
+-- Call this on individual rows; Snowflake batches them automatically.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION AI_DEIDENTIFY_TEXT(raw_text VARCHAR)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+SELECT (
+    SELECT OBJECT_CONSTRUCT(
+        'original_text', raw_text,
+        'deidentified_text',
+        REDUCE(
+            cleaned_entities,
+            raw_text::STRING,
+            (acc, el) -> REPLACE(
+                acc,
+                el:value::STRING,
+                '__ENTITY_' || el:type::STRING || '(' || el:token::STRING || ')__'
+            )
+        ),
+        'extracted_entities', cleaned_entities
+    )
+    FROM (
+        SELECT TRANSFORM(
+            TRANSFORM(
+                FILTER(
+                    LLM_EXTRACT_ENTITIES_BATCH(raw_text):entities,
+                    e -> e:value IS NOT NULL AND e:info_type IS NOT NULL
+                ),
+                e -> OBJECT_CONSTRUCT(
+                    'type', e:info_type::STRING,
+                    'value', e:value::STRING,
+                    'cleaned_value', CLEAN_SENSITIVE_VALUE(e:info_type::STRING, e:value::STRING)
+                )
+            ),
+            e -> OBJECT_INSERT(e, 'token', TOKENIZE_SENSITIVE_VALUE(e:cleaned_value::STRING))
+        ) AS cleaned_entities
+    )
+)
+$$;
+
+-- ============================================================================
+-- Example Usage:
+-- ============================================================================
+-- 
+-- -- Process table rows - Snowflake automatically batches calls to the vectorized UDF
+-- -- This leverages prompt caching across all rows in the batch
+-- SELECT 
+--     id,
+--     raw_text,
+--     AI_DEIDENTIFY_TEXT(raw_text) as result
+-- FROM my_table;
+--
+-- -- Extract specific fields from result
+-- SELECT 
+--     id,
+--     result:deidentified_text::STRING as deidentified_text,
+--     result:extracted_entities as entities
+-- FROM (
+--     SELECT id, AI_DEIDENTIFY_TEXT(raw_text) as result
+--     FROM my_table
+-- );
+--
+-- -- Check cache utilization
+-- SELECT 
+--     LLM_EXTRACT_ENTITIES_BATCH('Test text with john@test.com'):_meta as cache_info;


### PR DESCRIPTION
Replace SQL-based LLM_EXTRACT_ENTITIES_BATCH with wrapper functions that leverage the new vectorized Python UDF from ai_deidentify_batch_vectorized.sql.

Changes:
- Remove old LLM_EXTRACT_ENTITIES_BATCH SQL function (used SNOWFLAKE.CORTEX.TRY_COMPLETE)
- Add AI_DEIDENTIFY_TEXT_BATCH(ARRAY): flattens input array and calls vectorized UDF per-row with automatic batching
- Add AI_DEIDENTIFY_TEXT(VARCHAR): scalar wrapper for single text processing, auto-batched by Snowflake when used across multiple rows
- Refactor SQL to use CTEs for cleaner structure
- Update return type from structured_output parsing to direct entity extraction
- Update documentation header to reflect new dependencies

Benefits of vectorized UDF approach:
- Dynamic batching prevents token limit breaches
- Parallel API calls via asyncio for better throughput
- Prompt caching support via Cortex REST API
- Automatic SSE stream handling
- Unified error handling with success/error fields in response

Breaking change: Functions now depend on LLM_EXTRACT_ENTITIES_BATCH from ai_deidentify_batch_vectorized.sql instead of inline SQL implementation.

Fixes #4 